### PR TITLE
Fixed typographical error, changed accomodation to accommodation in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All the lectures and recitation activities and most of the in class coding sampl
 Policies
 ========
 ###Email###
-Email should only be used to set up an in person meeting or inform me about needed accomodations unless I tell you otherwise. Any other emails may not receive a response. All coursework related communications should be done through piazza, which allows anonymous posting. If you are uncomfortable with this policy, come to speak to me.
+Email should only be used to set up an in person meeting or inform me about needed accommodations unless I tell you otherwise. Any other emails may not receive a response. All coursework related communications should be done through piazza, which allows anonymous posting. If you are uncomfortable with this policy, come to speak to me.
 
 ###Piazza###
 We will be using Piazza for class discussion. The system is highly catered to getting you help fast and efficiently from classmates and myself. Rather than emailing questions to me, post your questions on Piazza. If you have any problems or feedback for the developers, email team@piazza.com.
@@ -58,7 +58,7 @@ Piazza Grade = [(.05*(days online+views)) + (.15*contributions)+(.15*questions) 
 * Provide documentation for any unexpected absence.
 
 ###Accessibility###
-* Have the accessibility center provide documentation for any accomodations ASAP
+* Have the accessibility center provide documentation for any accommodations ASAP
 * Notify me that they've left documentation in my mailbox/etc.
 
 ###Plagiarism###


### PR DESCRIPTION
@story645, I've corrected a typographical error in the documentation of the [cs102](https://github.com/story645/cs102) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.